### PR TITLE
Stronger typing of kernel options

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,10 @@
 * [`grubby`](#grubby): Manage bootloader configuration via grubby
 * [`grubby::config`](#grubbyconfig): Applies desired configuration via grubby
 
+### Data types
+
+* [`Grubby::Kernel_Opts`](#grubbykernel_opts): Parameters for each kernel argument
+
 ## Classes
 
 ### <a name="grubby"></a>`grubby`
@@ -61,7 +65,7 @@ The following parameters are available in the `grubby` class:
 
 ##### <a name="default_kernel"></a>`default_kernel`
 
-Data type: `Optional[String]`
+Data type: `Optional[String[1]]`
 
 The kernel version to set as default in the bootloader.
 
@@ -69,7 +73,7 @@ Default value: ``undef``
 
 ##### <a name="kernel_opts"></a>`kernel_opts`
 
-Data type: `Optional[Hash]`
+Data type: `Optional[Hash[String[1], Grubby::Kernel_Opts]]`
 
 The kernel options that should be managed
 for the default kernel
@@ -93,4 +97,20 @@ Default value: `{}`
 ### <a name="grubbyconfig"></a>`grubby::config`
 
 This is a private class, that performs the necessary changes via grubby
+
+## Data types
+
+### <a name="grubbykernel_opts"></a>`Grubby::Kernel_Opts`
+
+Parameters for each kernel argument
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['ensure'] => Enum['present','absent'],
+    Optional['value']  => Variant[Integer,String[1]],
+    Optional['scope']  => Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]],
+  }]
+```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,8 +47,8 @@
 #       ensure: absent
 #
 class grubby (
-  Optional[String] $default_kernel = undef,
-  Optional[Hash]   $kernel_opts    = {},
+  Optional[String[1]] $default_kernel                         = undef,
+  Optional[Hash[String[1], Grubby::Kernel_Opts]] $kernel_opts = {},
 ) {
   contain 'grubby::config'
 }

--- a/spec/type_aliases/grubby_kernel_opts_spec.rb
+++ b/spec/type_aliases/grubby_kernel_opts_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe 'Grubby::Kernel_Opts' do
+  it { is_expected.to allow_value('ensure' => 'present') }
+  it { is_expected.to allow_value('ensure' => 'absent') }
+  it { is_expected.to allow_value('value'  => 22) }
+  it { is_expected.to allow_value('value'  => 'foobar') }
+  it { is_expected.to allow_value('scope'  => 'ALL') }
+  it { is_expected.to allow_value('scope'  => 'DEFAULT') }
+  it { is_expected.to allow_value('scope'  => 'TITLE="CentOS Linux (4.18.0-240.15.1.el8_3.x86_64) 8"') }
+
+  it {
+    is_expected.to allow_value(
+      'ensure' => 'present',
+      'value'  => 25,
+      'scope'  => 'TITLE="CentOS Linux (4.18.0-240.15.1.el8_3.x86_64) 8"',
+    )
+  }
+
+  it { is_expected.not_to allow_value('ensure' => 'foo') }
+  it { is_expected.not_to allow_value('value' => true) }
+  it { is_expected.not_to allow_value('scope' => 'foo') }
+end

--- a/types/kernel_opts.pp
+++ b/types/kernel_opts.pp
@@ -1,0 +1,10 @@
+# @summary Parameters for each kernel argument
+#
+type Grubby::Kernel_Opts = Struct[
+  {
+    Optional['ensure'] => Enum['present','absent'],
+    Optional['value']  => Variant[Integer,String[1]],
+    Optional['scope']  => Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]],
+  }
+]
+


### PR DESCRIPTION
Inspired by me having a silent failure using an unquoted DEFAULT
below add some stronger typing.

```puppet
class{grubby:
  kernel_opts => {
    'sausage' => {
       scrope => DEFAULT,
    }
  }
}