### PR TITLE
Avoid test "grubby command" == "grubby command"

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ class grubby::config {
         }
       }
       'absent': {
-        exec { "Ensure ${_opt} kernel option is absent for ${scope}":
+        exec { "Ensure ${opt} kernel option is absent for ${scope}":
           command => "/sbin/grubby --update-kernel=${scope} --remove-args=${opt}",
           path    => ['/bin','/usr/bin'],
           unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -w ${opt}\"",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,7 +41,7 @@ class grubby::config {
         exec { "Ensure ${_opt} kernel option is absent for ${scope}":
           command => "/sbin/grubby --update-kernel=${scope} --remove-args=${opt}",
           path    => ['/bin','/usr/bin'],
-          unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -w ${_opt}\"",
+          unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -w ${opt}\"",
         }
       }
       default: {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,16 +34,14 @@ class grubby::config {
         exec { "Ensure ${_opt} kernel option is set for ${scope}":
           command => "/sbin/grubby --update-kernel=${scope} --args=${_opt}",
           path    => ['/bin','/usr/bin'],
-          unless  => "test `/sbin/grubby --info=${scope} | grep -c ^args=` == \
-                     `/sbin/grubby --info=${scope} | grep ^args= | grep -c ${_opt}`",
+          unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -wv ${_opt})\"",
         }
       }
       'absent': {
         exec { "Ensure ${_opt} kernel option is absent for ${scope}":
           command => "/sbin/grubby --update-kernel=${scope} --remove-args=${opt}",
           path    => ['/bin','/usr/bin'],
-          unless  => "test `/sbin/grubby --info=${scope} | grep -c ^args=` == \
-                     `/sbin/grubby --info=${scope} | grep ^args= | grep -vwc ${opt}`",
+          unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -w ${_opt}\"",
         }
       }
       default: {


### PR DESCRIPTION
In particular if the grubby command fails for what ever reason then both
sides fail and so both sides match.

Testing the basic cases:

```bash

cat << EOF | grep '^args='  | test -z "$(grep -wv rhgb)"
args="foo rhgb"
args="rhgb bar"
EOF

echo "Add rhgb ? Should return 0 since rhgb in each line, return code was $?"

cat << EOF | grep '^args='  | test -z "$(grep -wv rhgb)"
args="foo"
args="rhgb bar"
EOF

echo "Add rhgb ? Should return 1 since rhgb missing from one line, return code was $?"

cat << EOF | grep '^args='  | test -z "$(grep -w rhgb)"
args="foo"
args="bar"
EOF
echo "Delete rhgb ? Should return 0 since rhgb missing from all lines, return code was $?"

cat << EOF | grep '^args='  | test -z "$(grep -w rhgb)"
args="foo rhgb"
args="bar"
EOF
echo "Delete rhgb ? Should return 1 since rhgb present in one line, return code was  $?"

cat << EOF | grep '^args='  | test -z "$(grep -w rhgb)"
args="foo rhgb"
args="bar rhgb"
EOF
echo "Delete rhgb ? Should return 1 since rhgb present in all lines, return code was  $?"
```

Results in

```
dd rhgb ? Should return 0 since rhgb in each line, return code was 0
Add rhgb ? Should return 1 since rhgb missing from one line, return code was 1
Delete rhgb ? Should return 0 since rhgb missing from all lines, return code was 0
Delete rhgb ? Should return 1 since rhgb present in one line, return code was  1
Delete rhgb ? Should return 1 since rhgb present in all lines, return code was  1
```
as expected.