### PR TITLE
Restrict kernel parameters to not contain spaces

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,8 +47,8 @@
 #       ensure: absent
 #
 class grubby (
-  Optional[String[1]] $default_kernel                         = undef,
-  Optional[Hash[String[1], Grubby::Kernel_Opts]] $kernel_opts = {},
+  Optional[String[1]] $default_kernel                              = undef,
+  Optional[Hash[Pattern[/\S+/], Grubby::Kernel_Opts]] $kernel_opts = {},
 ) {
   contain 'grubby::config'
 }


### PR DESCRIPTION
Kernel parameters never have spaces in them so disallow that.

(Spaces in quoted values which is accepted is a harder problem)