### PR TITLE
Values of kernel parameters cannot contain spacesNospacevalue

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -77,7 +77,7 @@ Default value: ``undef``
 
 ##### <a name="kernel_opts"></a>`kernel_opts`
 
-Data type: `Optional[Hash[Pattern[/\S+/], Grubby::Kernel_Opts]]`
+Data type: `Optional[Hash[Pattern[/^\S+$/], Grubby::Kernel_Opts]]`
 
 The kernel options that should be managed
 for the default kernel
@@ -142,7 +142,7 @@ The following parameters are available in the `grubby::kernel_opt` defined type:
 
 ##### <a name="opt"></a>`opt`
 
-Data type: `String[1]`
+Data type: `Pattern[/^\S+$/]`
 
 Kernel option
 
@@ -158,7 +158,7 @@ Default value: `'present'`
 
 ##### <a name="value"></a>`value`
 
-Data type: `Optional[Variant[String[1],Integer]]`
+Data type: `Optional[Variant[Pattern[/^\S+$/],Integer]]`
 
 Value of kernel option
 
@@ -183,7 +183,7 @@ Alias of
 ```puppet
 Struct[{
     Optional['ensure'] => Enum['present','absent'],
-    Optional['value']  => Variant[Integer,String[1]],
+    Optional['value']  => Variant[Pattern[/^\S+$/],Integer],
     Optional['scope']  => Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]],
   }]
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -9,6 +9,10 @@
 * [`grubby`](#grubby): Manage bootloader configuration via grubby
 * [`grubby::config`](#grubbyconfig): Applies desired configuration via grubby
 
+### Defined types
+
+* [`grubby::kernel_opt`](#grubbykernel_opt): Applies kernel parameter configuration via grubby
+
 ### Data types
 
 * [`Grubby::Kernel_Opts`](#grubbykernel_opts): Parameters for each kernel argument
@@ -73,7 +77,7 @@ Default value: ``undef``
 
 ##### <a name="kernel_opts"></a>`kernel_opts`
 
-Data type: `Optional[Hash[String[1], Grubby::Kernel_Opts]]`
+Data type: `Optional[Hash[Pattern[/\S+/], Grubby::Kernel_Opts]]`
 
 The kernel options that should be managed
 for the default kernel
@@ -97,6 +101,76 @@ Default value: `{}`
 ### <a name="grubbyconfig"></a>`grubby::config`
 
 This is a private class, that performs the necessary changes via grubby
+
+## Defined types
+
+### <a name="grubbykernel_opt"></a>`grubby::kernel_opt`
+
+}
+
+#### Examples
+
+##### Add Single Parameter
+
+```puppet
+grubby::kernel_opt{'keyword':}
+```
+
+##### Delete a Single Parameter
+
+```puppet
+grubby::kernel_opt{'selinix':
+  ensure => 'absent',
+}
+```
+
+##### Add Parameter with Value
+
+```puppet
+grubby::kernel_opt{'memsize':
+  value  => '22',
+```
+
+#### Parameters
+
+The following parameters are available in the `grubby::kernel_opt` defined type:
+
+* [`opt`](#opt)
+* [`ensure`](#ensure)
+* [`value`](#value)
+* [`scope`](#scope)
+
+##### <a name="opt"></a>`opt`
+
+Data type: `String[1]`
+
+Kernel option
+
+Default value: `$name`
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+add or delete kernel option
+
+Default value: `'present'`
+
+##### <a name="value"></a>`value`
+
+Data type: `Optional[Variant[String[1],Integer]]`
+
+Value of kernel option
+
+Default value: ``undef``
+
+##### <a name="scope"></a>`scope`
+
+Data type: `Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]]`
+
+Which kernels to apply parameters to
+
+Default value: `'DEFAULT'`
 
 ## Data types
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,34 +19,9 @@ class grubby::config {
   }
 
   $grubby::kernel_opts.each | $opt, $fields | {
-    $scope = $fields[scope] ? {
-      Undef   => 'DEFAULT',
-      default => $fields[scope],
-    }
-
-    $_opt = $fields[value] ? {
-      Undef   => $opt,
-      default => "${opt}=${fields[value]}",
-    }
-
-    case $fields[ensure] {
-      Undef, 'present': {
-        exec { "Ensure ${_opt} kernel option is set for ${scope}":
-          command => "/sbin/grubby --update-kernel=${scope} --args=${_opt}",
-          path    => ['/bin','/usr/bin'],
-          unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -wv ${_opt})\"",
-        }
-      }
-      'absent': {
-        exec { "Ensure ${opt} kernel option is absent for ${scope}":
-          command => "/sbin/grubby --update-kernel=${scope} --remove-args=${opt}",
-          path    => ['/bin','/usr/bin'],
-          unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -w ${opt}\"",
-        }
-      }
-      default: {
-        fail('Incorect value of field ensure for $opt kernel option!')
-      }
+    grubby::kernel_opt{$opt:
+      *=> $fields,
     }
   }
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,8 +47,8 @@
 #       ensure: absent
 #
 class grubby (
-  Optional[String[1]] $default_kernel                              = undef,
-  Optional[Hash[Pattern[/\S+/], Grubby::Kernel_Opts]] $kernel_opts = {},
+  Optional[String[1]] $default_kernel                                = undef,
+  Optional[Hash[Pattern[/^\S+$/], Grubby::Kernel_Opts]] $kernel_opts = {},
 ) {
   contain 'grubby::config'
 }

--- a/manifests/kernel_opt.pp
+++ b/manifests/kernel_opt.pp
@@ -1,0 +1,52 @@
+# @summary Applies kernel parameter configuration via grubby
+#
+# @example Add Single Parameter
+#   grubby::kernel_opt{'keyword':}
+#
+# @example Delete a Single Parameter
+#   grubby::kernel_opt{'selinix':
+#     ensure => 'absent',
+#   }
+#
+# @example Add Parameter with Value
+#   grubby::kernel_opt{'memsize':
+#     value  => '22',
+# }
+#
+# @param opt Kernel option
+# @param ensure add or delete kernel option
+# @param value Value of kernel option
+# @param scope Which kernels to apply parameters to
+#
+define grubby::kernel_opt (
+  Pattern[/\S+/] $opt                                           = $name,
+  Enum['present', 'absent']                             $ensure = 'present',
+  Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]]  $scope  = 'DEFAULT',
+  Optional[Variant[String[1],Integer]]                  $value  =  undef,
+){
+
+  $_opt = $value ? {
+    Undef   => $opt,
+    default => "${opt}=${value}",
+  }
+
+  case $ensure {
+    'present': {
+      exec { "Ensure ${_opt} kernel option is set for ${scope}":
+        command => "/sbin/grubby --update-kernel=${scope} --args=${_opt}",
+        path    => ['/bin','/usr/bin'],
+        unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -wv ${_opt})\"",
+      }
+    }
+    'absent': {
+      exec { "Ensure ${opt} kernel option is absent for ${scope}":
+        command => "/sbin/grubby --update-kernel=${scope} --remove-args=${opt}",
+        path    => ['/bin','/usr/bin'],
+        unless  => "/sbin/grubby --info=${scope} | grep ^args= | test -z \"$(grep -w ${opt})\"",
+      }
+    }
+    default: {
+      fail('Incorect value of field ensure for ensure parameter!')
+    }
+  }
+}

--- a/manifests/kernel_opt.pp
+++ b/manifests/kernel_opt.pp
@@ -19,10 +19,10 @@
 # @param scope Which kernels to apply parameters to
 #
 define grubby::kernel_opt (
-  Pattern[/\S+/] $opt                                           = $name,
+  Pattern[/^\S+$/] $opt                                           = $name,
   Enum['present', 'absent']                             $ensure = 'present',
   Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]]  $scope  = 'DEFAULT',
-  Optional[Variant[String[1],Integer]]                  $value  =  undef,
+  Optional[Variant[Pattern[/^\S+$/],Integer]]           $value  =  undef,
 ){
 
   $_opt = $value ? {

--- a/spec/defines/kernel_opt_spec.rb
+++ b/spec/defines/kernel_opt_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe 'grubby::kernel_opt' do
+  let(:title) { 'foo' }
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) do
+        os_facts
+      end
+
+      it { is_expected.to compile }
+      context 'with no parameters' do
+        it do
+          is_expected.to contain_exec('Ensure foo kernel option is set for DEFAULT').with(
+            command: '/sbin/grubby --update-kernel=DEFAULT --args=foo',
+            unless: '/sbin/grubby --info=DEFAULT | grep ^args= | test -z "$(grep -wv foo)"',
+          )
+        end
+        context 'with value and scope set' do
+          let(:params) do
+            { value: 'bar', scope: 'ALL' }
+          end
+
+          it do
+            is_expected.to contain_exec('Ensure foo=bar kernel option is set for ALL').with(
+              command: '/sbin/grubby --update-kernel=ALL --args=foo=bar',
+              unless: '/sbin/grubby --info=ALL | grep ^args= | test -z "$(grep -wv foo=bar)"',
+            )
+          end
+        end
+      end
+      context 'with ensure absent parameters' do
+        let(:params) do
+          { ensure: 'absent' }
+        end
+
+        it do
+          is_expected.to contain_exec('Ensure foo kernel option is absent for DEFAULT').with(
+            command: '/sbin/grubby --update-kernel=DEFAULT --remove-args=foo',
+            unless: '/sbin/grubby --info=DEFAULT | grep ^args= | test -z "$(grep -w foo)"',
+          )
+        end
+        context 'with value and scope set' do
+          let(:params) do
+            super().merge(value: 'bar', scope: 'ALL')
+          end
+
+          it do
+            is_expected.to contain_exec('Ensure foo kernel option is absent for ALL').with(
+              command: '/sbin/grubby --update-kernel=ALL --remove-args=foo',
+              unless: '/sbin/grubby --info=ALL | grep ^args= | test -z "$(grep -w foo)"',
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/shared_examples/config.rb
+++ b/spec/shared_examples/config.rb
@@ -27,11 +27,14 @@ shared_examples_for 'grubby::config' do |_default_facts|
                                                               value: 'ball',
                                                               scope: 'ALL')
       }
+      it { is_expected.to contain_exec('Ensure bar=10 kernel option is set for DEFAULT') }
+
       it {
         is_expected.to contain_grubby__kernel_opt('bar').with(ensure: 'present',
                                                               value: 10,
                                                               scope: 'DEFAULT')
       }
+      it { is_expected.to contain_exec('Ensure foo=ball kernel option is set for ALL') }
     end
   end
 end

--- a/spec/shared_examples/config.rb
+++ b/spec/shared_examples/config.rb
@@ -12,5 +12,26 @@ shared_examples_for 'grubby::config' do |_default_facts|
                                                                unless: '/sbin/grubby --default-kernel | grep -q /boot/vmlinuz-2.6.32-431.23.3.el6.x86_64')
       end
     end
+    context 'when kernel_opts is defined' do
+      let(:params) do
+        { kernel_opts: { 'foo' => {
+          'ensure' => 'present', 'value' => 'ball', 'scope' => 'ALL'
+        },
+                         'bar' => {
+                           'ensure' => 'present', 'value' => 10
+                         } } }
+      end
+
+      it {
+        is_expected.to contain_grubby__kernel_opt('foo').with(ensure: 'present',
+                                                              value: 'ball',
+                                                              scope: 'ALL')
+      }
+      it {
+        is_expected.to contain_grubby__kernel_opt('bar').with(ensure: 'present',
+                                                              value: 10,
+                                                              scope: 'DEFAULT')
+      }
+    end
   end
 end

--- a/spec/type_aliases/grubby_kernel_opts_spec.rb
+++ b/spec/type_aliases/grubby_kernel_opts_spec.rb
@@ -19,5 +19,6 @@ describe 'Grubby::Kernel_Opts' do
 
   it { is_expected.not_to allow_value('ensure' => 'foo') }
   it { is_expected.not_to allow_value('value' => true) }
+  it { is_expected.not_to allow_value('value' => 'spaced value') }
   it { is_expected.not_to allow_value('scope' => 'foo') }
 end

--- a/types/kernel_opts.pp
+++ b/types/kernel_opts.pp
@@ -3,7 +3,7 @@
 type Grubby::Kernel_Opts = Struct[
   {
     Optional['ensure'] => Enum['present','absent'],
-    Optional['value']  => Variant[Integer,String[1]],
+    Optional['value']  => Variant[Pattern[/^\S+$/],Integer],
     Optional['scope']  => Variant[Enum['DEFAULT','ALL'],Pattern[/^TITLE=.+$/]],
   }
 ]


### PR DESCRIPTION
While according

https://www.kernel.org/doc/html/v4.14/admin-guide/kernel-para

parameter values can be specified as a space separated list

```
param="A B"
```

it is not obvious that grubby supports such an addition.

So best to fail if presented with a space containing value.

If ever required check branch here
https://github.com/atsonkov/puppet-module-grubby/pull/11

